### PR TITLE
Cellのエラー修正

### DIFF
--- a/StudyApp/ViewController/Storyboard/TimelineTableViewCell.xib
+++ b/StudyApp/ViewController/Storyboard/TimelineTableViewCell.xib
@@ -77,16 +77,8 @@
             </connections>
             <point key="canvasLocation" x="174.63768115942031" y="197.87946428571428"/>
         </tableViewCell>
-        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="un4-f6-hA7">
-            <rect key="frame" x="0.0" y="0.0" width="24" height="25"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <fontDescription key="fontDescription" type="system" pointSize="15"/>
-            <state key="normal" image="coment.png"/>
-            <point key="canvasLocation" x="225" y="463"/>
-        </button>
     </objects>
     <resources>
-        <image name="coment.png" width="26" height="26"/>
         <image name="heart.png" width="24" height="24"/>
         <image name="more.png" width="30" height="30"/>
         <image name="profile_icon.png" width="500" height="500"/>


### PR DESCRIPTION
![スクリーンショット 2021-05-18 2 45 59](https://user-images.githubusercontent.com/62977964/118533759-694a2e00-b783-11eb-929f-3553d6ef67f6.png)
このCellに入っていないボタンが悪さしていました

エラーは
```
"invalid nib registered for identifier (Cell) - nib must contain exactly one top level object which must be a UITableViewCell instance"

（Cellというidentifierのnibが無効です - nibのトップレベルのオブジェクトは必ず"一つ"で、UITableViewCellインスタンスでなければなりません的な）
```
なので、トップレベルに2つ（Cell と Button）があることが問題でした